### PR TITLE
Feat: give output as json from abi-based methods

### DIFF
--- a/lib/evmlib/src/api.rs
+++ b/lib/evmlib/src/api.rs
@@ -1,14 +1,10 @@
 // This is free and unencumbered software released into the public domain.
 
-#[allow(unused_imports)]
 use crate::{
     env::Env,
+    json_utils::{decode::transform_json_call_data, encode::encode_return_data_as_json},
     ops::{ENV, EVM},
-    state::{Word, ZERO},
-};
-use abi_types::ethabi::{
-    self,
-    ethereum_types::{H160, U256},
+    state::Word,
 };
 
 #[no_mangle]
@@ -70,7 +66,7 @@ pub unsafe fn _evm_init(_table_offset: u32, chain_id: u64, balance: u64) {
         EVM.trace_level = 0; // TODO: look for --trace in args
 
         EVM.call_value = match args.next() {
-            None => ZERO,
+            None => crate::state::ZERO,
             Some(s) => Word::from(s.parse::<u64>().unwrap_or(0)), // TODO: support decimal point as well
         };
         //eprintln!("_evm_init: call_data={:?} call_value={:?}", ENV.call_data, EVM.call_value);
@@ -121,6 +117,26 @@ pub unsafe fn _evm_call(
     }
 }
 
+/// Posts the return value from the execution, translating into JSON using the ABI
+#[no_mangle]
+pub unsafe fn _evm_post_exec(
+    output_types_off: usize, // relative to _abi_buffer
+    output_types_len: usize,
+) {
+    // If there is an ABI given then we will try to encode output into JSON
+    if output_types_len > 0 {
+        let output_types_ptr: *mut u8 = _abi_buffer
+            .as_mut_ptr()
+            .offset(output_types_off.try_into().unwrap());
+        let output_types = std::slice::from_raw_parts(output_types_ptr, output_types_len);
+        let json_return_data =
+            encode_return_data_as_json(output_types, ENV.get_return_data(), ENV.get_exit_status())
+                .unwrap();
+        ENV.overwrite_return_data(json_return_data);
+    }
+    ENV.post_exec();
+}
+
 #[no_mangle]
 pub unsafe fn _evm_pop_u32() -> u32 {
     EVM.stack.pop().as_u32()
@@ -130,198 +146,4 @@ pub unsafe fn _evm_pop_u32() -> u32 {
 pub unsafe fn _evm_set_pc(pc: u32) {
     #[cfg(feature = "pc")]
     EVM.program_counter = pc;
-}
-
-/// Transforms the given call_data (assumed to be json format) into solidity-encoded input
-/// using the given ABI (parameter names and types).
-fn transform_json_call_data(
-    selector: u32,
-    param_names: &[u8],
-    param_types: &[u8],
-    json_call_data: &[u8],
-) -> Result<Vec<u8>, TransformCallDataError> {
-    let param_names =
-        std::str::from_utf8(param_names).map_err(|_| TransformCallDataError::InvalidUtf8String)?;
-    let param_types =
-        std::str::from_utf8(param_types).map_err(|_| TransformCallDataError::InvalidUtf8String)?;
-    assert_eq!(
-        param_names.split(',').count(),
-        param_types.split(',').count(),
-        "Expected same number of parameter names and types"
-    );
-    let parsed_json: serde_json::Value =
-        serde_json::from_slice(json_call_data).map_err(|_| TransformCallDataError::InvalidJson)?;
-    let json_object = parsed_json
-        .as_object()
-        .ok_or(TransformCallDataError::NotJsonObject)?;
-    let mut abi_tokens: Vec<ethabi::Token> = Vec::with_capacity(param_names.len());
-    for (name, typ) in param_names.split(',').zip(param_types.split(',')) {
-        let abi_type =
-            abi_types::parse_param_type(typ).map_err(|_| TransformCallDataError::InvalidAbiType)?;
-        let param_value = json_object
-            .get(name)
-            .ok_or(TransformCallDataError::MissingParameter)?;
-        let abi_value = parse_json_value_to_abi_type(param_value, &abi_type)?;
-        abi_tokens.push(abi_value);
-    }
-    let args = ethabi::encode(&abi_tokens);
-    let selector_bytes: &[u8] = &selector.to_be_bytes();
-    Ok([selector_bytes, &args].concat())
-}
-
-fn parse_json_value_to_abi_type(
-    param_value: &serde_json::Value,
-    abi_type: &ethabi::ParamType,
-) -> Result<ethabi::Token, TransformCallDataError> {
-    match abi_type {
-        ethabi::ParamType::Address => {
-            let address_bytes = param_value
-                .as_str()
-                .and_then(|s| hex::decode(s.strip_prefix("0x").unwrap_or(s)).ok())
-                .ok_or(TransformCallDataError::InvalidAbiValue)?;
-            let address_bytes: [u8; 20] = address_bytes
-                .try_into()
-                .map_err(|_| TransformCallDataError::InvalidAbiValue)?;
-            Ok(ethabi::Token::Address(H160(address_bytes)))
-        }
-        ethabi::ParamType::Bytes => {
-            let bytes = param_value
-                .as_str()
-                .and_then(|s| hex::decode(s.strip_prefix("0x").unwrap_or(s)).ok())
-                .ok_or(TransformCallDataError::InvalidAbiValue)?;
-            Ok(ethabi::Token::Bytes(bytes))
-        }
-        ethabi::ParamType::Int(_) => {
-            let number = parse_json_value_to_i256(param_value)?;
-            Ok(ethabi::Token::Int(number))
-        }
-        ethabi::ParamType::Uint(_) => {
-            let number = parse_json_value_to_u256(param_value)?;
-            Ok(ethabi::Token::Uint(number))
-        }
-        ethabi::ParamType::Bool => param_value
-            .as_bool()
-            .map(ethabi::Token::Bool)
-            .ok_or(TransformCallDataError::InvalidAbiValue),
-        ethabi::ParamType::String => param_value
-            .as_str()
-            .map(|s| ethabi::Token::String(String::from(s)))
-            .ok_or(TransformCallDataError::InvalidAbiValue),
-        ethabi::ParamType::Array(inner_abi_type) => {
-            let inner_values = param_value
-                .as_array()
-                .ok_or(TransformCallDataError::InvalidAbiValue)?;
-            let mut inner_abi_values = Vec::with_capacity(inner_values.len());
-            for v in inner_values {
-                inner_abi_values.push(parse_json_value_to_abi_type(v, inner_abi_type)?);
-            }
-            Ok(ethabi::Token::Array(inner_abi_values))
-        }
-        ethabi::ParamType::FixedBytes(fixed_len) => {
-            let bytes = param_value
-                .as_str()
-                .and_then(|s| hex::decode(s.strip_prefix("0x").unwrap_or(s)).ok())
-                .ok_or(TransformCallDataError::InvalidAbiValue)?;
-            if &bytes.len() != fixed_len {
-                return Err(TransformCallDataError::InvalidAbiValue);
-            }
-            Ok(ethabi::Token::FixedBytes(bytes))
-        }
-        ethabi::ParamType::FixedArray(inner_abi_type, fixed_len) => {
-            let inner_values = param_value
-                .as_array()
-                .ok_or(TransformCallDataError::InvalidAbiValue)?;
-            if &inner_values.len() != fixed_len {
-                return Err(TransformCallDataError::InvalidAbiValue);
-            }
-            let mut inner_abi_values = Vec::with_capacity(inner_values.len());
-            for v in inner_values {
-                inner_abi_values.push(parse_json_value_to_abi_type(v, inner_abi_type)?);
-            }
-            Ok(ethabi::Token::FixedArray(inner_abi_values))
-        }
-        ethabi::ParamType::Tuple(inner_abi_types) => {
-            let inner_values = param_value
-                .as_array()
-                .ok_or(TransformCallDataError::InvalidAbiValue)?;
-            if inner_values.len() != inner_abi_types.len() {
-                return Err(TransformCallDataError::InvalidAbiValue);
-            }
-            let mut inner_abi_values = Vec::with_capacity(inner_values.len());
-            for (v, t) in inner_values.iter().zip(inner_abi_types.iter()) {
-                inner_abi_values.push(parse_json_value_to_abi_type(v, t)?);
-            }
-            Ok(ethabi::Token::Tuple(inner_abi_values))
-        }
-    }
-}
-
-fn parse_json_value_to_u256(value: &serde_json::Value) -> Result<U256, TransformCallDataError> {
-    match value {
-        serde_json::Value::String(s) => {
-            let parsed = if s.starts_with("0x") {
-                ethabi::ethereum_types::U256::from_str_radix(s, 16)
-            } else {
-                ethabi::ethereum_types::U256::from_str_radix(s, 10)
-            };
-            parsed.map_err(|_| TransformCallDataError::InvalidAbiValue)
-        }
-        serde_json::Value::Number(num) => num
-            .as_u64()
-            .map(U256::from)
-            .ok_or(TransformCallDataError::InvalidAbiValue),
-        _ => Err(TransformCallDataError::InvalidAbiValue),
-    }
-}
-
-fn parse_json_value_to_i256(value: &serde_json::Value) -> Result<U256, TransformCallDataError> {
-    match value {
-        serde_json::Value::String(s) => {
-            let parsed = if s.starts_with("0x") {
-                ethabi::ethereum_types::U256::from_str_radix(s, 16)
-                    .map_err(|_| TransformCallDataError::InvalidAbiValue)?
-            } else {
-                let number = ethnum::i256::from_str_radix(s, 10)
-                    .map_err(|_| TransformCallDataError::InvalidAbiValue)?;
-                let bytes = number.to_be_bytes();
-                U256::from_big_endian(&bytes)
-            };
-            Ok(parsed)
-        }
-        serde_json::Value::Number(num) => num
-            .as_i64()
-            .map(|i| {
-                let number = ethnum::i256::from(i);
-                let bytes = number.to_be_bytes();
-                U256::from_big_endian(&bytes)
-            })
-            .ok_or(TransformCallDataError::InvalidAbiValue),
-        _ => Err(TransformCallDataError::InvalidAbiValue),
-    }
-}
-
-#[derive(Debug)]
-enum TransformCallDataError {
-    InvalidUtf8String,
-    InvalidJson,
-    NotJsonObject,
-    InvalidAbiType,
-    MissingParameter,
-    InvalidAbiValue,
-}
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn test_transform_json_call_data() {
-        let output = super::transform_json_call_data(
-            0x3c4308a8,
-            b"a,b",
-            b"int256,int256",
-            r#"{"a": 6, "b": 7}"#.as_bytes(),
-        )
-        .unwrap();
-        let expected_output = hex::decode("3c4308a800000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000007").unwrap();
-        assert_eq!(output, expected_output);
-    }
 }

--- a/lib/evmlib/src/env/mock.rs
+++ b/lib/evmlib/src/env/mock.rs
@@ -89,33 +89,47 @@ impl Env for MockEnv {
     fn value_return(&mut self, return_data: &[u8]) {
         self.return_data = return_data.to_vec();
         self.exit_status = Some(ExitStatus::Success);
-
-        #[cfg(not(test))]
-        {
-            eprintln!("RETURN 0x{}", hex::encode(return_data));
-            std::process::exit(0); // EX_OK
-        }
     }
 
     fn revert(&mut self, return_data: &[u8]) {
         self.return_data = return_data.to_vec();
         self.exit_status = Some(ExitStatus::Revert);
-
-        #[cfg(not(test))]
-        {
-            eprintln!("REVERT 0x{}", hex::encode(return_data));
-            std::process::exit(64); // EX_USAGE
-        }
     }
 
     fn exit_oog(&mut self) {
         self.exit_status = Some(ExitStatus::OutOfGas);
+    }
 
-        #[cfg(not(test))]
-        {
-            eprintln!("OUT OF GAS");
-            std::process::exit(64); // EX_USAGE
+    fn post_exec(&self) {
+        match &self.exit_status {
+            Some(ExitStatus::Success) => {
+                eprintln!("RETURN 0x{}", hex::encode(&self.return_data));
+                std::process::exit(0); // EX_OK
+            }
+            Some(ExitStatus::Revert) => {
+                eprintln!("REVERT 0x{}", hex::encode(&self.return_data));
+                std::process::exit(64); // EX_USAGE
+            }
+            Some(ExitStatus::OutOfGas) => {
+                eprintln!("OUT OF GAS");
+                std::process::exit(64); // EX_USAGE
+            }
+            None => {
+                panic!("Exited without any status being set!")
+            }
         }
+    }
+
+    fn get_return_data(&self) -> &[u8] {
+        &self.return_data
+    }
+
+    fn get_exit_status(&self) -> &Option<ExitStatus> {
+        &self.exit_status
+    }
+
+    fn overwrite_return_data(&mut self, return_data: Vec<u8>) {
+        self.return_data = return_data;
     }
 }
 

--- a/lib/evmlib/src/env/mod.rs
+++ b/lib/evmlib/src/env/mod.rs
@@ -25,6 +25,13 @@ pub trait Env {
     fn revert(&mut self, return_data: &[u8]);
     /// Exit due to out of gas
     fn exit_oog(&mut self);
+    /// Called when all execution is finished to post the result
+    /// to the parent runtime (eg NEAR runtime).
+    fn post_exec(&self);
+    fn get_return_data(&self) -> &[u8];
+    fn get_exit_status(&self) -> &Option<ExitStatus>;
+    /// Used to when encoding the output as JSON instead of raw bytes
+    fn overwrite_return_data(&mut self, return_data: Vec<u8>);
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/lib/evmlib/src/json_utils/decode.rs
+++ b/lib/evmlib/src/json_utils/decode.rs
@@ -1,0 +1,200 @@
+//! A collection of functions for decoding JSON into ethabi::Token values.
+
+use abi_types::ethabi::{
+    self,
+    ethereum_types::{H160, U256},
+};
+
+/// Transforms the given call_data (assumed to be json format) into solidity-encoded input
+/// using the given ABI (parameter names and types).
+pub fn transform_json_call_data(
+    selector: u32,
+    param_names: &[u8],
+    param_types: &[u8],
+    json_call_data: &[u8],
+) -> Result<Vec<u8>, TransformCallDataError> {
+    let param_names =
+        std::str::from_utf8(param_names).map_err(|_| TransformCallDataError::InvalidUtf8String)?;
+    let param_types =
+        std::str::from_utf8(param_types).map_err(|_| TransformCallDataError::InvalidUtf8String)?;
+    assert_eq!(
+        param_names.split(',').count(),
+        param_types.split(',').count(),
+        "Expected same number of parameter names and types"
+    );
+    let parsed_json: serde_json::Value =
+        serde_json::from_slice(json_call_data).map_err(|_| TransformCallDataError::InvalidJson)?;
+    let json_object = parsed_json
+        .as_object()
+        .ok_or(TransformCallDataError::NotJsonObject)?;
+    let mut abi_tokens: Vec<ethabi::Token> = Vec::with_capacity(param_names.len());
+    for (name, typ) in param_names.split(',').zip(param_types.split(',')) {
+        let abi_type =
+            abi_types::parse_param_type(typ).map_err(|_| TransformCallDataError::InvalidAbiType)?;
+        let param_value = json_object
+            .get(name)
+            .ok_or(TransformCallDataError::MissingParameter)?;
+        let abi_value = parse_json_value_to_abi_type(param_value, &abi_type)?;
+        abi_tokens.push(abi_value);
+    }
+    let args = ethabi::encode(&abi_tokens);
+    let selector_bytes: &[u8] = &selector.to_be_bytes();
+    Ok([selector_bytes, &args].concat())
+}
+
+fn parse_json_value_to_abi_type(
+    param_value: &serde_json::Value,
+    abi_type: &ethabi::ParamType,
+) -> Result<ethabi::Token, TransformCallDataError> {
+    match abi_type {
+        ethabi::ParamType::Address => {
+            let address_bytes = param_value
+                .as_str()
+                .and_then(|s| hex::decode(s.strip_prefix("0x").unwrap_or(s)).ok())
+                .ok_or(TransformCallDataError::InvalidAbiValue)?;
+            let address_bytes: [u8; 20] = address_bytes
+                .try_into()
+                .map_err(|_| TransformCallDataError::InvalidAbiValue)?;
+            Ok(ethabi::Token::Address(H160(address_bytes)))
+        }
+        ethabi::ParamType::Bytes => {
+            let bytes = param_value
+                .as_str()
+                .and_then(|s| hex::decode(s.strip_prefix("0x").unwrap_or(s)).ok())
+                .ok_or(TransformCallDataError::InvalidAbiValue)?;
+            Ok(ethabi::Token::Bytes(bytes))
+        }
+        ethabi::ParamType::Int(_) => {
+            let number = parse_json_value_to_i256(param_value)?;
+            Ok(ethabi::Token::Int(number))
+        }
+        ethabi::ParamType::Uint(_) => {
+            let number = parse_json_value_to_u256(param_value)?;
+            Ok(ethabi::Token::Uint(number))
+        }
+        ethabi::ParamType::Bool => param_value
+            .as_bool()
+            .map(ethabi::Token::Bool)
+            .ok_or(TransformCallDataError::InvalidAbiValue),
+        ethabi::ParamType::String => param_value
+            .as_str()
+            .map(|s| ethabi::Token::String(String::from(s)))
+            .ok_or(TransformCallDataError::InvalidAbiValue),
+        ethabi::ParamType::Array(inner_abi_type) => {
+            let inner_values = param_value
+                .as_array()
+                .ok_or(TransformCallDataError::InvalidAbiValue)?;
+            let mut inner_abi_values = Vec::with_capacity(inner_values.len());
+            for v in inner_values {
+                inner_abi_values.push(parse_json_value_to_abi_type(v, inner_abi_type)?);
+            }
+            Ok(ethabi::Token::Array(inner_abi_values))
+        }
+        ethabi::ParamType::FixedBytes(fixed_len) => {
+            let bytes = param_value
+                .as_str()
+                .and_then(|s| hex::decode(s.strip_prefix("0x").unwrap_or(s)).ok())
+                .ok_or(TransformCallDataError::InvalidAbiValue)?;
+            if &bytes.len() != fixed_len {
+                return Err(TransformCallDataError::InvalidAbiValue);
+            }
+            Ok(ethabi::Token::FixedBytes(bytes))
+        }
+        ethabi::ParamType::FixedArray(inner_abi_type, fixed_len) => {
+            let inner_values = param_value
+                .as_array()
+                .ok_or(TransformCallDataError::InvalidAbiValue)?;
+            if &inner_values.len() != fixed_len {
+                return Err(TransformCallDataError::InvalidAbiValue);
+            }
+            let mut inner_abi_values = Vec::with_capacity(inner_values.len());
+            for v in inner_values {
+                inner_abi_values.push(parse_json_value_to_abi_type(v, inner_abi_type)?);
+            }
+            Ok(ethabi::Token::FixedArray(inner_abi_values))
+        }
+        ethabi::ParamType::Tuple(inner_abi_types) => {
+            let inner_values = param_value
+                .as_array()
+                .ok_or(TransformCallDataError::InvalidAbiValue)?;
+            if inner_values.len() != inner_abi_types.len() {
+                return Err(TransformCallDataError::InvalidAbiValue);
+            }
+            let mut inner_abi_values = Vec::with_capacity(inner_values.len());
+            for (v, t) in inner_values.iter().zip(inner_abi_types.iter()) {
+                inner_abi_values.push(parse_json_value_to_abi_type(v, t)?);
+            }
+            Ok(ethabi::Token::Tuple(inner_abi_values))
+        }
+    }
+}
+
+fn parse_json_value_to_u256(value: &serde_json::Value) -> Result<U256, TransformCallDataError> {
+    match value {
+        serde_json::Value::String(s) => {
+            let parsed = if s.starts_with("0x") {
+                ethabi::ethereum_types::U256::from_str_radix(s, 16)
+            } else {
+                ethabi::ethereum_types::U256::from_str_radix(s, 10)
+            };
+            parsed.map_err(|_| TransformCallDataError::InvalidAbiValue)
+        }
+        serde_json::Value::Number(num) => num
+            .as_u64()
+            .map(U256::from)
+            .ok_or(TransformCallDataError::InvalidAbiValue),
+        _ => Err(TransformCallDataError::InvalidAbiValue),
+    }
+}
+
+fn parse_json_value_to_i256(value: &serde_json::Value) -> Result<U256, TransformCallDataError> {
+    match value {
+        serde_json::Value::String(s) => {
+            let parsed = if s.starts_with("0x") {
+                ethabi::ethereum_types::U256::from_str_radix(s, 16)
+                    .map_err(|_| TransformCallDataError::InvalidAbiValue)?
+            } else {
+                let number = ethnum::i256::from_str_radix(s, 10)
+                    .map_err(|_| TransformCallDataError::InvalidAbiValue)?;
+                let bytes = number.to_be_bytes();
+                U256::from_big_endian(&bytes)
+            };
+            Ok(parsed)
+        }
+        serde_json::Value::Number(num) => num
+            .as_i64()
+            .map(|i| {
+                let number = ethnum::i256::from(i);
+                let bytes = number.to_be_bytes();
+                U256::from_big_endian(&bytes)
+            })
+            .ok_or(TransformCallDataError::InvalidAbiValue),
+        _ => Err(TransformCallDataError::InvalidAbiValue),
+    }
+}
+
+#[derive(Debug)]
+pub enum TransformCallDataError {
+    InvalidUtf8String,
+    InvalidJson,
+    NotJsonObject,
+    InvalidAbiType,
+    MissingParameter,
+    InvalidAbiValue,
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_transform_json_call_data() {
+        let output = super::transform_json_call_data(
+            0x3c4308a8,
+            b"a,b",
+            b"int256,int256",
+            r#"{"a": 6, "b": 7}"#.as_bytes(),
+        )
+        .unwrap();
+        let expected_output = hex::decode("3c4308a800000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000007").unwrap();
+        assert_eq!(output, expected_output);
+    }
+}

--- a/lib/evmlib/src/json_utils/encode.rs
+++ b/lib/evmlib/src/json_utils/encode.rs
@@ -1,0 +1,134 @@
+//! A collection of functions for encoding ethabi::Token values into JSON.
+
+use crate::env::ExitStatus;
+use abi_types::ethabi;
+
+/// Given a string which lists the ABI types of a function's output, the exit status, and the
+/// return data from the EVM execution; this function attempts to create a json object to encode
+/// this output and returns it serialized into bytes.
+pub fn encode_return_data_as_json(
+    output_types: &[u8],
+    return_data: &[u8],
+    exit_status: &Option<ExitStatus>,
+) -> Result<Vec<u8>, EncodeReturnDataError> {
+    let exit_status = exit_status.ok_or(EncodeReturnDataError::NoExitStatus)?;
+    let mut json_result = serde_json::Map::new();
+    match exit_status {
+        ExitStatus::Success => {
+            json_result.insert("status".into(), serde_json::Value::String("SUCCESS".into()));
+            let output_types = std::str::from_utf8(output_types)
+                .map_err(|_| EncodeReturnDataError::InvalidUtf8String)?;
+
+            let mut abi_types = Vec::new();
+            for output in output_types.split(',') {
+                let abi_type = abi_types::parse_param_type(output)
+                    .map_err(|_| EncodeReturnDataError::InvalidAbiType)?;
+                abi_types.push(abi_type);
+            }
+            let mut return_tokens = ethabi::decode(&abi_types, return_data)
+                .map_err(|_| EncodeReturnDataError::ReturnDataDecodeFailure)?;
+            let json_value = if return_tokens.len() == 1 {
+                // unwrap is safe because we checked the length
+                ethabi_token_to_json_value(return_tokens.pop().unwrap())
+            } else {
+                ethabi_token_to_json_value(ethabi::Token::Tuple(return_tokens))
+            };
+            json_result.insert("output".into(), json_value);
+        }
+        ExitStatus::Revert => {
+            json_result.insert("status".into(), serde_json::Value::String("REVERT".into()));
+            // Check for standard Solidity error format
+            if return_data[0..4] == [0x08, 0xc3, 0x79, 0xa0] {
+                let mut return_tokens =
+                    ethabi::decode(&[ethabi::ParamType::String], &return_data[4..])
+                        .map_err(|_| EncodeReturnDataError::ReturnDataDecodeFailure)?;
+                // Unwrap is statically safe because we passed only a single type to decode
+                let error_message = return_tokens.pop().unwrap();
+                let json_value = ethabi_token_to_json_value(error_message);
+                json_result.insert("error".into(), json_value);
+            } else {
+                let json_value =
+                    serde_json::Value::String(format!("0x{}", hex::encode(return_data)));
+                json_result.insert("error".into(), json_value);
+            }
+        }
+        ExitStatus::OutOfGas => {
+            json_result.insert(
+                "status".into(),
+                serde_json::Value::String("OUT_OF_GAS".into()),
+            );
+        }
+    }
+    let json_data = serde_json::to_vec(&json_result)
+        .map_err(|_| EncodeReturnDataError::JsonSerializationFailure)?;
+    Ok(json_data)
+}
+
+fn ethabi_token_to_json_value(token: ethabi::Token) -> serde_json::Value {
+    match token {
+        ethabi::Token::Address(address) => {
+            serde_json::Value::String(format!("0x{}", hex::encode(address.as_bytes())))
+        }
+        ethabi::Token::FixedBytes(bytes) => {
+            serde_json::Value::String(format!("0x{}", hex::encode(bytes)))
+        }
+        ethabi::Token::Bytes(bytes) => {
+            serde_json::Value::String(format!("0x{}", hex::encode(bytes)))
+        }
+        ethabi::Token::Int(number) => {
+            let be_bytes = {
+                let mut buf = [0u8; 32];
+                number.to_big_endian(&mut buf);
+                buf
+            };
+            let signed_number = ethnum::i256::from_be_bytes(be_bytes);
+            match i64::try_from(signed_number) {
+                Ok(n) => serde_json::Value::Number(serde_json::value::Number::from(n)),
+                Err(_) => serde_json::Value::String(signed_number.to_string()),
+            }
+        }
+        ethabi::Token::Uint(number) => match u64::try_from(number) {
+            Ok(n) => serde_json::Value::Number(serde_json::value::Number::from(n)),
+            Err(_) => serde_json::Value::String(number.to_string()),
+        },
+        ethabi::Token::Bool(value) => serde_json::Value::Bool(value),
+        ethabi::Token::String(value) => serde_json::Value::String(value),
+        ethabi::Token::FixedArray(values) => {
+            let inner_values = values.into_iter().map(ethabi_token_to_json_value).collect();
+            serde_json::Value::Array(inner_values)
+        }
+        ethabi::Token::Array(values) => {
+            let inner_values = values.into_iter().map(ethabi_token_to_json_value).collect();
+            serde_json::Value::Array(inner_values)
+        }
+        ethabi::Token::Tuple(values) => {
+            let inner_values = values.into_iter().map(ethabi_token_to_json_value).collect();
+            serde_json::Value::Array(inner_values)
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum EncodeReturnDataError {
+    NoExitStatus,
+    InvalidUtf8String,
+    InvalidAbiType,
+    ReturnDataDecodeFailure,
+    JsonSerializationFailure,
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_encode_return_data_as_json() {
+        let output = super::encode_return_data_as_json(
+            b"int256",
+            &hex::decode("000000000000000000000000000000000000000000000000000000000000002A")
+                .unwrap(),
+            &Some(crate::env::ExitStatus::Success),
+        )
+        .unwrap();
+        let expected_output = r#"{"output":42,"status":"SUCCESS"}"#.as_bytes();
+        assert_eq!(&output, expected_output);
+    }
+}

--- a/lib/evmlib/src/json_utils/mod.rs
+++ b/lib/evmlib/src/json_utils/mod.rs
@@ -1,0 +1,2 @@
+pub mod decode;
+pub mod encode;

--- a/lib/evmlib/src/lib.rs
+++ b/lib/evmlib/src/lib.rs
@@ -5,6 +5,7 @@
 mod api;
 mod env;
 mod hash_provider;
+mod json_utils;
 mod near_runtime;
 mod ops;
 mod state;

--- a/lib/evmlib/src/ops.rs
+++ b/lib/evmlib/src/ops.rs
@@ -45,6 +45,7 @@ pub(crate) static mut ENV: crate::near_runtime::NearRuntime = crate::near_runtim
     origin_cache: None,
     caller_cache: None,
     exit_status: None,
+    return_data: Vec::new(),
 };
 
 #[cfg(any(not(feature = "near"), test))]


### PR DESCRIPTION
This allows nice output when calling from the NEAR CLI. Example:

```
$ near --networkId testnet --accountId birchmd.testnet call dev-1663014663747-27418521013742 multiply '{"a": 7, "b": 6}'

Scheduling a call: dev-1663014663747-27418521013742.multiply({"a": 7, "b": 6})
Doing account.functionCall()
Transaction Id 97g3DMfcZMyipJ5QLzRw46d6SvnjsTdyn1B1ZVH5w7fg
To see the transaction in the transaction explorer, please open this url in your browser
https://explorer.testnet.near.org/transactions/97g3DMfcZMyipJ5QLzRw46d6SvnjsTdyn1B1ZVH5w7fg
{ output: 42, status: 'SUCCESS' }
```

This feature is implemented by having environment functions like `value_return` and `revert` only update the internal EVM state (setting the exit status and return data), not call any external exit methods (like `process::exit`, or NEAR's host functions). Instead, the exit calls happen as part of a new function called `post_exec`. This gives a chance for the return data to be re-encoded from ABI into JSON before the value is returned.

The main files to focus on in the review are: `compiler.rs`, `api.rs` and `encode.rs`. Note that the code for decoding JSON into ABI input was simply moved from `api.rs` to `decode.rs` with no changes.